### PR TITLE
option to force quotes on string values

### DIFF
--- a/lib/hjson.js
+++ b/lib/hjson.js
@@ -492,7 +492,7 @@ var Hjson = (function () {
       if (!string) return '""';
 
       needsQuotes.lastIndex = 0;
-      var doEscape = hasComment || needsQuotes.test(string);
+      var doEscape = hasComment || needsQuotes.test(string) || (!!options.force_quotes);
 
       // Check if we can insert this string without quotes
       // see hjson syntax (must not parse as true, false, null or number)
@@ -680,8 +680,11 @@ var Hjson = (function () {
     // Return the hjson_stringify function. It will have access to all of the above
     // functions and variables.
 
+    var options;
     return function (value, opt) {
       var i, space;
+
+      options = opt;
 
       indent = '  ';
       keepWsc = false;


### PR DESCRIPTION
hi,

I would like to make my `hjson.stringify()` output to look like js objects:

```javascript
var obj = {
	key: "string value"
}
```

therefore it would be handy to have an option to force quotes on string values, if desired — `hjson.stringify(obj, { force_quotes: true })`.

what do you think?